### PR TITLE
docs: fix simple typo, domention -> dimension

### DIFF
--- a/codes/python/advanced/custom_training.py
+++ b/codes/python/advanced/custom_training.py
@@ -7,7 +7,7 @@ import numpy as np
 x_train = x_train / 255.0
 x_test = x_test / 255.0
 
-# Add one domention to make 3D images
+# Add one dimension to make 3D images
 x_train = x_train[...,tf.newaxis]
 x_test = x_test[...,tf.newaxis]
 

--- a/codes/python/advanced/dataset_generator.py
+++ b/codes/python/advanced/dataset_generator.py
@@ -28,7 +28,7 @@ import numpy as np
 x_train = x_train / 255.0
 x_test = x_test / 255.0
 
-# Add one domention to make 3D images
+# Add one dimension to make 3D images
 x_train = x_train[...,tf.newaxis]
 x_test = x_test[...,tf.newaxis]
 

--- a/codes/python/neural_networks/cnns.py
+++ b/codes/python/neural_networks/cnns.py
@@ -15,7 +15,7 @@ import tensorflow as tf
 x_train = x_train / 255.0
 x_test = x_test / 255.0
 
-# Add one domention to make 3D images
+# Add one dimension to make 3D images
 x_train = x_train[...,tf.newaxis]
 x_test = x_test[...,tf.newaxis]
 


### PR DESCRIPTION
There is a small typo in codes/python/advanced/custom_training.py, codes/python/advanced/dataset_generator.py, codes/python/neural_networks/cnns.py.

Should read `dimension` rather than `domention`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md